### PR TITLE
Updating Dockerfile for build efficiency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,17 @@
 FROM node:16.13.2-alpine
 
 # create destination directory
-RUN mkdir -p /usr/src/website-shot
 WORKDIR /usr/src/website-shot
 
 # update and install dependency
-RUN apk update && apk upgrade
-RUN apk add git
-RUN apk add chromium
+RUN apk add --no-cache git chromium
+
+# copy package.json and install dependencies
+COPY package*.json /usr/src/website-shot/
+RUN npm install
 
 # copy the app, note .dockerignore
 COPY . /usr/src/website-shot/
-RUN npm install
 RUN npm run build
 
 EXPOSE 3000


### PR DESCRIPTION
- Removing update and upgrade. --no-cache assume update
- Removing mkdir. Not needed as WORKDIR will create folder
- Adding git and chromium install to one line to have less layers
- Separating copy of package.json combined with npm install:
  Initial build takes around 200s. Unless there are changes to the package.json file, builds will take around 2-3s